### PR TITLE
Update sysprox.py

### DIFF
--- a/proxverter/sysprox.py
+++ b/proxverter/sysprox.py
@@ -291,7 +291,7 @@ class Proxy:
             prox = win_proxy(self.ip_address, self.port)
         elif plat == "linux":
             prox = lin_proxy(self.ip_address, self.port)
-        elif plat == "macos":
+        elif plat in ("macos", 'darwin'):
             prox = mac_proxy(self.ip_address, self.port)
         else:
             raise OSError("Unable to determine the underlying operating system")


### PR DESCRIPTION
`platform.system().lower()` returns `darwin` for macos which causes `OSError: Unable to determine the underlying operating system`.
It's fixed.